### PR TITLE
fix: decimal type cannot be used for frontend, change to float

### DIFF
--- a/src/lambda/lambda_function.py
+++ b/src/lambda/lambda_function.py
@@ -3,6 +3,7 @@ import os
 import logging
 import boto3
 from botocore.exceptions import ClientError
+from decimal import Decimal
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -10,6 +11,11 @@ logger.setLevel(logging.INFO)
 dynamodb = boto3.resource('dynamodb')
 table_name = os.environ.get('PROJECT_VIEWS_TABLE_NAME', 'portfolio-insight-project-views')
 project_views_table = dynamodb.Table(table_name)
+
+def decimal_to_float(obj):
+    if isinstance(obj, Decimal):
+        return float(obj)
+    raise TypeError
 
 def lambda_handler(event, context):
     """
@@ -72,7 +78,7 @@ def get_all_project_views(headers):
         return {
             'statusCode': 200,
             'headers': headers,
-            'body': json.dumps(result, default=str)
+            'body': json.dumps(result, default=decimal_to_float)
         }
     
     except ClientError as e:
@@ -121,7 +127,7 @@ def increment_project_view(event, headers):
             'body': json.dumps({
                 'message': 'View count incremented',
                 'project': updated_item
-            }, default=str)
+            }, default=decimal_to_float)
         }
         
     except ClientError as e:

--- a/src/template/template.yaml
+++ b/src/template/template.yaml
@@ -95,6 +95,7 @@ Resources:
           import logging
           import boto3
           from botocore.exceptions import ClientError
+          from decimal import Decimal
 
           logger = logging.getLogger()
           logger.setLevel(logging.INFO)
@@ -102,6 +103,11 @@ Resources:
           dynamodb = boto3.resource('dynamodb')
           table_name = os.environ.get('PROJECT_VIEWS_TABLE_NAME', 'portfolio-insight-project-views')
           project_views_table = dynamodb.Table(table_name)
+
+          def decimal_to_float(obj):
+              if isinstance(obj, Decimal):
+                  return float(obj)
+              raise TypeError
 
           def lambda_handler(event, context):
               """
@@ -164,7 +170,7 @@ Resources:
                   return {
                       'statusCode': 200,
                       'headers': headers,
-                      'body': json.dumps(result)
+                      'body': json.dumps(result, default=decimal_to_float)
                   }
               
               except ClientError as e:
@@ -213,7 +219,7 @@ Resources:
                       'body': json.dumps({
                           'message': 'View count incremented',
                           'project': updated_item
-                      })
+                      }, default=decimal_to_float)
                   }
                   
               except ClientError as e:
@@ -229,6 +235,7 @@ Resources:
                       'headers': headers,
                       'body': json.dumps({'error': 'Invalid JSON in request body'})
                   }
+
       Tags:
         - Key: Project
           Value: !Ref ProjectName


### PR DESCRIPTION
# Lambda Decimal to Float Conversion PR

## 修改摘要

本次 PR 主要修改了 Lambda 函數處理 DynamoDB 數據的方式，將從 DynamoDB 讀取的 Decimal 類型數值轉換為 float 類型，以確保正確的 JSON 序列化。

## 修改內容

1. **添加了 Decimal 轉 float 的輔助函數**:
   ```python
   def decimal_to_float(obj):
       if isinstance(obj, Decimal):
           return float(obj)
       raise TypeError
   ```

2. **修改 JSON 序列化方式**:
   - 在 `get_all_project_views` 函數中，將 `json.dumps` 的 `default` 參數設為 `decimal_to_float`
   - 在 `increment_project_view` 函數中，同樣將 `json.dumps` 的 `default` 參數設為 `decimal_to_float`

## 預期解決問題

- 修正 "Object of type Decimal is not JSON serializable" 錯誤
- 確保 API 回傳的 JSON 中的數字是實際的數值類型，而非字串
- 前端應用程式可以直接使用數值進行計算，不需要額外轉換